### PR TITLE
Connect to default database to find all databases

### DIFF
--- a/install/assets/functions/10-db-backup
+++ b/install/assets/functions/10-db-backup
@@ -268,10 +268,9 @@ backup_mysql() {
 
 backup_pgsql() {
   export PGPASSWORD=${DB_PASS}
-  authdb=${DB_USER}
     if [ "${DB_NAME,,}" = "all" ] ; then
         print_debug "Preparing to back up all databases"
-        db_names=$(psql -h ${DB_HOST} -U ${DB_USER} -p ${DB_PORT} -d ${authdb} -c 'COPY (SELECT datname FROM pg_database WHERE datistemplate = false) TO STDOUT;' )
+        db_names=$(psql -h ${DB_HOST} -U ${DB_USER} -p ${DB_PORT} -c 'COPY (SELECT datname FROM pg_database WHERE datistemplate = false) TO STDOUT;' )
         if [ -n "${DB_NAME_EXCLUDE}" ] ; then
             db_names_exclusions=$(echo "${DB_NAME_EXCLUDE}" | tr ',' '\n')
             for db_exclude in ${db_names_exclusions} ; do
@@ -306,7 +305,7 @@ backup_pgsql() {
         compression
         pre_dbbackup all
         print_notice "Dumping all PostgreSQL databases: '$(echo ${db_names} | xargs | tr ' ' ',')' ${compression_string}"
-        tmp_db_names=$(psql -h ${DB_HOST} -U ${DB_USER} -p ${DB_PORT} -d ${authdb} -c 'COPY (SELECT datname FROM pg_database WHERE datistemplate = false) TO STDOUT;' )
+        tmp_db_names=$(psql -h ${DB_HOST} -U ${DB_USER} -p ${DB_PORT} -c 'COPY (SELECT datname FROM pg_database WHERE datistemplate = false) TO STDOUT;' )
         for r_db_name in $(echo $db_names  | xargs); do
             tmp_db_names=$(echo "$tmp_db_names" | xargs | sed "s|${r_db_name}||g"  )
         done


### PR DESCRIPTION
The `psql` call for finding all databases (which happens when `DB_NAME` is `ALL` or `SPLIT_DB` is `FALSE`) fails if `DB_USER` is not an existing database. This change stops using `DB_USER` for the `-d` option.

If you run `psql` without specifying `-d`/`--dbname`, it uses `postgres` by default, going so far as to raise an error if it is missing:
```
/ # psql -U postgres
psql: error: FATAL:  database "postgres" does not exist
```
I think it makes sense to use the same assumption for the `psql` call mentioned above.

---

For users who don't have the default `postgres` database in their cluster, we could add a new configuration option `DB_SOMETHING_OR_OTHER` that would be `postgres` by default. What do you think?

---

This may close #196.