### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ See more details in the base image listed above for more mail environment variab
 Fetch a `MATRIX_ACCESS_TOKEN`:
 
 ````
-curl -XPOST -d '{"type":"m.login.password", "user":"myuserid", "password":"mypass"}' "https://matrix.org/_matrix/client/r0/login"
+curl -XPOST -H 'Content-Type: application/json' -d '{"type":"m.login.password", "user":"myuserid", "password":"mypass"}' "https://matrix.org/_matrix/client/r0/login"
 ````
 
 Copy the JSON response `access_token` that will look something like this:


### PR DESCRIPTION
Fix README documentation about Matrix Notifications, adding a `application/json` header. Without it, the request returns this error:

`{"errcode":"M_NOT_JSON","error":"Invalid Content-Type header: expected application/json"}`