### PR TITLE
fix: Fix download blobxfer when BLOBXFER_REMOTE_PATH has folders

### DIFF
--- a/examples/mssql-blobxfer/compose.yml
+++ b/examples/mssql-blobxfer/compose.yml
@@ -28,11 +28,11 @@ services:
     # image: tiredofit/db-backup
     image: tiredofit/db-backup
     links:
-     - example-mssql-s3-db
+      - example-mssql-s3-db
     volumes:
       - ./backups:/backup
       - ./tmp/backups:/tmp/backups    # shared tmp backup directory
-      #- ./post-script.sh:/assets/custom-scripts/post-script.sh
+    #- ./post-script.sh:/assets/custom-scripts/post-script.sh
     environment:
       - TIMEZONE=America/Vancouver
       - CONTAINER_ENABLE_MONITORING=FALSE
@@ -58,7 +58,8 @@ services:
       - DB01_BLOBXFER_STORAGE_ACCOUNT={TODO Add Storage Name}
       # Add here azure storage account key
       - DB01_BLOBXFER_STORAGE_ACCOUNT_KEY={TODO Add Key}
-      - DB01_BLOBXFER_REMOTE_PATH=docker-db-backup
+      # Optional nested path, e.g. test/weekly (leading/trailing slashes are not required)
+      - DB01_BLOBXFER_REMOTE_PATH=backup01/docker-db-backup
     restart: always
     networks:
       example-mssql-blobxfer-net:

--- a/install/assets/functions/10-db-backup
+++ b/install/assets/functions/10-db-backup
@@ -1677,6 +1677,18 @@ EOF
                     write_log info "Synchronize local storage from blob container with blobxfer"
                     ${play_fair} blobxfer download --no-overwrite --mode ${backup_job_blobxfer_mode} --remote-path ${backup_job_blobxfer_remote_path} --storage-account ${backup_job_blobxfer_storage_account} --storage-account-key ${backup_job_blobxfer_storage_account_key} --local-path ${backup_job_filesystem_path} --restore-file-lmt --delete
 
+                    # Avoid recursively re-uploading the downloaded remote path when a nested remote directory is configured.
+                    blobxfer_remote_path_clean=$(echo "${backup_job_blobxfer_remote_path}" | sed -e 's#^/*##' -e 's#/*$##')
+                    case "${blobxfer_remote_path_clean}" in
+                        */*)
+                            blobxfer_local_mirror_path="${backup_job_filesystem_path}/${blobxfer_remote_path_clean}"
+                            if [ -d "${blobxfer_local_mirror_path}" ]; then
+                                write_log debug "Removing local blobxfer mirror path ${blobxfer_local_mirror_path} to prevent recursive nesting"
+                                run_as_user rm -rf "${blobxfer_local_mirror_path}"
+                            fi
+                        ;;
+                    esac
+
                     write_log info "Moving backup to external storage with blobxfer"
                     mkdir -p "${backup_job_filesystem_path}"
                     if [ "${backup_job_checksum}" != "none" ] ; then run_as_user mv "${temporary_directory}"/*."${checksum_extension}" "${backup_job_filesystem_path}"/; fi


### PR DESCRIPTION
**Problem**

When Blobxfer was configured with a nested remote path (for example /test/weekly/), each backup cycle could reintroduce the same path segment and produce recursive nesting over time (for example /test/weekly/test/weekly/...).
The root cause was the download + upload flow: remote content was first downloaded into the local backup directory, then the same directory was uploaded back to the same remote path, so mirrored subfolders could be re-uploaded repeatedly.

First run
'/environment/weekly/'
Second run
'/environment/weekly/environment/weekly/'
...

**What was changed**

Added path-safety logic to prevent recursive re-upload of the downloaded remote mirror when nested remote paths are used.