### PR TITLE
feat: support {db} placeholder in EXTRA_BACKUP_OPTS for split-mode ba…

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Encryption occurs after compression and the encrypted filename will have a `.gpg
 | Variable                           | Description                                                                                               | Default                   | `_FILE` |
 | ---------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------- | ------- |
 | `DEFAULT_PORT`                     | MySQL / MariaDB Port                                                                                      | `3306`                    | x       |
-| `DEFAULT_EXTRA_BACKUP_OPTS`        | Pass extra arguments to the backup command only, add them here e.g. `--extra-command`                     |                           |         |
+| `DEFAULT_EXTRA_BACKUP_OPTS`        | Pass extra arguments to the backup command only, add them here e.g. `--extra-command`. Supports `{db}` placeholder for current database name in split mode (e.g. `--ignore-table={db}.logs`) |                           |         |
 | `DEFAULT_EXTRA_ENUMERATION_OPTS`   | Pass extra arguments to the database enumeration command only, add them here e.g. `--extra-command`       |                           |         |
 | `DEFAULT_EXTRA_OPTS`               | Pass extra arguments to the backup and database enumeration command, add them here e.g. `--extra-command` |                           |         |
 | `DEFAULT_MYSQL_CLIENT`             | Choose between `mariadb` or `mysql` client to perform dump operations for compatibility purposes          | `mariadb`                 |         |

--- a/install/assets/functions/10-db-backup
+++ b/install/assets/functions/10-db-backup
@@ -736,7 +736,8 @@ backup_mysql() {
                 pre_dbbackup "${db}"
                 write_log notice "Dumping MySQL/MariaDB database: '${db}' ${compression_string}"
                 if var_true "${DEBUG_BACKUP_MYSQL}" ; then debug on; fi
-                run_as_user ${play_fair} ${_mysql_prefix}${_mysql_bin_prefix}dump --max-allowed-packet=${backup_job_mysql_max_allowed_packet} -h ${backup_job_db_host} -P ${backup_job_db_port} -u${backup_job_db_user} ${events} ${single_transaction} ${stored_procedures} ${mysql_tls_args} ${backup_job_extra_opts} ${backup_job_extra_backup_opts} $db | ${compress_cmd} | run_as_user tee "${temporary_directory}"/"${backup_job_filename}" > /dev/null
+                extra_backup_opts="${backup_job_extra_backup_opts//\{db\}/$db}"
+                run_as_user ${play_fair} ${_mysql_prefix}${_mysql_bin_prefix}dump --max-allowed-packet=${backup_job_mysql_max_allowed_packet} -h ${backup_job_db_host} -P ${backup_job_db_port} -u${backup_job_db_user} ${events} ${single_transaction} ${stored_procedures} ${mysql_tls_args} ${backup_job_extra_opts} ${extra_backup_opts} $db | ${compress_cmd} | run_as_user tee "${temporary_directory}"/"${backup_job_filename}" > /dev/null
                 exit_code=$((PIPESTATUS[0] + PIPESTATUS[1] + PIPESTATUS[2]))
                 if var_true "${DEBUG_BACKUP_MYSQL}" ; then debug off; fi
                 check_exit_code backup "${backup_job_filename}"
@@ -829,7 +830,8 @@ backup_pgsql() {
                 pre_dbbackup "${db}"
                 write_log notice "Dumping PostgresSQL database: '${db}' ${compression_string}"
                 if var_true "${DEBUG_BACKUP_PGSQL}" ; then debug on; fi
-                run_as_user ${play_fair} pg_dump -h "${backup_job_db_host}" -p "${backup_job_db_port}" -U "${backup_job_db_user}" $db ${backup_job_extra_opts} ${backup_job_extra_backup_opts} | ${compress_cmd} | run_as_user tee "${temporary_directory}"/"${backup_job_filename}" > /dev/null
+                extra_backup_opts="${backup_job_extra_backup_opts//\{db\}/$db}"
+                run_as_user ${play_fair} pg_dump -h "${backup_job_db_host}" -p "${backup_job_db_port}" -U "${backup_job_db_user}" $db ${backup_job_extra_opts} ${extra_backup_opts} | ${compress_cmd} | run_as_user tee "${temporary_directory}"/"${backup_job_filename}" > /dev/null
                 exit_code=$((PIPESTATUS[0] + PIPESTATUS[1] + PIPESTATUS[2]))
                 if var_true "${DEBUG_BACKUP_PGSQL}" ; then debug off; fi
                 check_exit_code backup "${backup_job_filename}"


### PR DESCRIPTION
…ckups

Allow dynamic substitution of the current database name in EXTRA_BACKUP_OPTS using the {db} placeholder. When SPLIT_DB=true, {db} is replaced with the current database name before each backup command executes.

This enables patterns like --ignore-table={db}.logs to work across 100+ databases without hardcoding each database name.