### PR TITLE
Report a failed move to the backup location as a failed backup to Zabbix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.9.3 2026-08-30 <foellmann at wus-technik dot com>
+
+   ### Changed
+      - Report a failed move to the backup location as a failed backup to Zabbix, so that the
+        `[{#NAME}] Backup - Failed with errors` trigger fires when a dump never reached its
+        destination
+
+
 ## 4.9.2 2026-08-24 <code at nfrastack dot com>
 
    ### Changed

--- a/rootfs/container/functions/10-dbbackup
+++ b/rootfs/container/functions/10-dbbackup
@@ -1630,10 +1630,15 @@ dbbackup_post_dbbackup() {
         silent dbbackup_run_as_user zabbix_sender -c "${ZABBIX_CONFIG_PATH}"/"${ZABBIX_CONFIG_FILE}" -k dbbackup.backup -o '[{"{#NAME}":"'${backup_job_db_host}.${backup_job_db_name}'"}]'
         local zabbix_payload=$(dbbackup_run_as_user mktemp)
 
+        ## The backup only counts as successful when it also reached its destination -
+        ## exit_code covers the dump alone, move_exit_code the move to the backup location.
+        local zabbix_status="${exit_code}"
+        if [ "${move_exit_code:-0}" != "0" ] ; then zabbix_status=1 ; fi
+
         cat <<EOZP | silent dbbackup_run_as_user tee "${zabbix_payload}"
 - dbbackup.backup.size.[${backup_job_db_host}.${backup_job_db_name}] "${dbbackup_size}"
 - dbbackup.backup.datetime.[${backup_job_db_host}.${backup_job_db_name}] "${dbbackup_date}"
-- dbbackup.backup.status.[${backup_job_db_host}.${backup_job_db_name}] "${exit_code}"
+- dbbackup.backup.status.[${backup_job_db_host}.${backup_job_db_name}] "${zabbix_status}"
 - dbbackup.backup.duration.[${backup_job_db_host}.${backup_job_db_name}] "$((dbbackup_finish_time-dbbackup_start_time))"
 - dbbackup.backup.filename.[${backup_job_db_host}.${backup_job_db_name}] "${backup_job_filename}"
 EOZP


### PR DESCRIPTION
## The problem

`dbbackup.backup.status` carries `${exit_code}`, which is the exit code of the **dump alone** — it is assigned right after the dump command and before `dbbackup_move_dbbackup` runs:

```
silent dbbackup_run_as_user ${play_fair} mongodump ...
exit_code=$?
...
dbbackup_move_dbbackup          # sets move_exit_code
dbbackup_check_exit_code move "${backup_job_filename}"
dbbackup_post_dbbackup "${backup_job_db_name}"   # sends ${exit_code} to Zabbix
```

A dump that was written correctly but never reached its S3 bucket, filesystem path or blob container is therefore reported to Zabbix as a **successful backup**, and the template's only status trigger, `last(/DB Backup4/dbbackup.backup.status.[{#NAME}])=1`, stays silent.

The remaining items do not catch it either: `dbbackup_size`, `filename` and especially `dbbackup_date` are read from the dump in the temporary directory before the move, so even an age based `fuzzytime()` trigger sees a fresh backup while the destination holds nothing.

Outside of Zabbix the failure is visible only in the container log and through `dbbackup_notify`, which does nothing unless `NOTIFICATION_TYPE` is configured. A destination that silently stops accepting uploads can therefore go unnoticed for a long time.

## The change

Send the move result along with the dump result. The status stays `0` only when both the dump and the move succeeded, so the existing trigger fires without any change to the template:

```bash
local zabbix_status="${exit_code}"
if [ "${move_exit_code:-0}" != "0" ] ; then zabbix_status=1 ; fi
```

This changes behaviour for existing installations: jobs whose upload currently fails silently will start showing up as `Backup - Failed with errors`. That is the intent — but it is worth calling out, since it may surface failures that were previously invisible.

## Testing

Verified with the released container image against a stubbed `zabbix_sender`, three runs:

| Run | Script | `dbbackup.backup.status` |
|---|---|---|
| Move succeeded (filesystem) | patched | `0` |
| S3 endpoint unreachable | patched | `1` |
| S3 endpoint unreachable | unpatched `main` | `0` |

The third run is the control: same failure, without the patch.

## Note

This branch is independent of my two other PRs. It adds a `4.9.3` CHANGELOG heading, as does #494 — whichever merges second will need a trivial conflict resolution at the top of the file.
