### PR TITLE
Fix the Zabbix template's alerting and bring it to Zabbix 7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 4.9.3 2026-08-30 <foellmann at wus-technik dot com>
+
+   ### Changed
+      - Zabbix template: fix the tiered "No backups detected" triggers - the 3, 4 and 5 day
+        expressions each also required the backup to be younger than 2 days and could therefore
+        never fire, and the 2 day trigger resolved itself once a backup aged past 3 days, leaving
+        a permanently failing job unalarmed
+      - Zabbix template: `Backup 20% Smaller in Size` compared against 0.2 (80% smaller) instead
+        of 0.8, and both size ratio triggers now guard against a zero previous value
+      - Zabbix template: export version raised to 7.4, backup size given `B` units, and the
+        template description pointed at the current repository
+
+   ### Added
+      - Zabbix template: `No statistics received` trigger with a `{$DBBACKUP.NODATA.PERIOD}`
+        macro, catching a backup job that stops reporting altogether
+
+
 ## 4.9.2 2026-08-24 <code at nfrastack dot com>
 
    ### Changed

--- a/zabbix_templates/db_backup.json
+++ b/zabbix_templates/db_backup.json
@@ -1,6 +1,6 @@
 {
     "zabbix_export": {
-        "version": "6.4",
+        "version": "7.4",
         "template_groups": [
             {
                 "uuid": "10b88d2b3a3a4c72b43bdce9310e1162",
@@ -16,7 +16,7 @@
                 "uuid": "5a16c1bd694145389eed5ee803d954cc",
                 "template": "DB Backup4",
                 "name": "DB Backup4",
-                "description": "Template for Docker DB Backup Image\n\nMeant for use specifically with https://github.com/tiredofit/docker-db-backup Version > 4.0.0\n\nSupports auto discovery of backup jobs and creates graphs and triggers",
+                "description": "Template for Docker DB Backup Image\n\nMeant for use specifically with https://github.com/nfrastack/db-backup Version > 4.0.0\n\nSupports auto discovery of backup jobs and creates graphs and triggers",
                 "groups": [
                     {
                         "name": "DB/Backup"
@@ -82,28 +82,28 @@
                                 "trigger_prototypes": [
                                     {
                                         "uuid": "3681b56bb882466fb304a48b4beb15f0",
-                                        "expression": "fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],172800s)=0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],259200s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],345600s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],432800s)<>0",
+                                        "expression": "fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],172800s)=0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],259200s)<>0",
                                         "name": "[{#NAME}] No backups detected in 2 days",
                                         "priority": "HIGH",
                                         "manual_close": "YES"
                                     },
                                     {
                                         "uuid": "6c70136c84994197b6396a143b4e956f",
-                                        "expression": "fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],172800s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],259200s)=0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],345600s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],432800s)<>0",
+                                        "expression": "fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],259200s)=0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],345600s)<>0",
                                         "name": "[{#NAME}] No backups detected in 3 days",
                                         "priority": "DISASTER",
                                         "manual_close": "YES"
                                     },
                                     {
                                         "uuid": "d2038025cab643019cb9610c301f0cb9",
-                                        "expression": "fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],172800s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],259200s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],345600s)=0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],432800s)<>0",
+                                        "expression": "fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],345600s)=0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],432000s)<>0",
                                         "name": "[{#NAME}] No backups detected in 4 days",
                                         "priority": "DISASTER",
                                         "manual_close": "YES"
                                     },
                                     {
                                         "uuid": "ea85f02d032c4a1dbc1b6e91a3b2b37b",
-                                        "expression": "fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],172800s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],259200s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],345600s)<>0 and fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],432800s)=0",
+                                        "expression": "fuzzytime(/DB Backup4/dbbackup.backup.datetime.[{#NAME}],432000s)=0",
                                         "name": "[{#NAME}] No backups detected in 5 days",
                                         "priority": "DISASTER",
                                         "manual_close": "YES"
@@ -164,6 +164,7 @@
                                 "key": "dbbackup.backup.size.[{#NAME}]",
                                 "delay": "0",
                                 "history": "7d",
+                                "units": "B",
                                 "description": "Backup Size",
                                 "tags": [
                                     {
@@ -174,15 +175,15 @@
                                 "trigger_prototypes": [
                                     {
                                         "uuid": "849f8660bee04427aff55af47b6f509c",
-                                        "expression": "last(/DB Backup4/dbbackup.backup.size.[{#NAME}])/last(/DB Backup4/dbbackup.backup.size.[{#NAME}],#2)>1.2",
+                                        "expression": "last(/DB Backup4/dbbackup.backup.size.[{#NAME}],#2)>0 and last(/DB Backup4/dbbackup.backup.size.[{#NAME}])/last(/DB Backup4/dbbackup.backup.size.[{#NAME}],#2)>1.2",
                                         "name": "[{#NAME}] Backup 20% Greater in size",
                                         "priority": "WARNING",
                                         "manual_close": "YES"
                                     },
                                     {
                                         "uuid": "74d16a7680544c65af22cc568ce3d59d",
-                                        "expression": "last(/DB Backup4/dbbackup.backup.size.[{#NAME}])/last(/DB Backup4/dbbackup.backup.size.[{#NAME}],#2)<0.2",
-                                        "name": "[{#NAME}]  Backup 20% Smaller in Size",
+                                        "expression": "last(/DB Backup4/dbbackup.backup.size.[{#NAME}],#2)>0 and last(/DB Backup4/dbbackup.backup.size.[{#NAME}])/last(/DB Backup4/dbbackup.backup.size.[{#NAME}],#2)<0.8",
+                                        "name": "[{#NAME}] Backup 20% Smaller in Size",
                                         "priority": "WARNING",
                                         "manual_close": "YES"
                                     },
@@ -219,6 +220,14 @@
                                         "name": "[{#NAME}] Backup - Failed with errors",
                                         "priority": "WARNING",
                                         "manual_close": "YES"
+                                    },
+                                    {
+                                        "uuid": "6714ee70e9274e9888c85294bd96a866",
+                                        "expression": "nodata(/DB Backup4/dbbackup.backup.status.[{#NAME}],{$DBBACKUP.NODATA.PERIOD})=1",
+                                        "name": "[{#NAME}] Backup - No statistics received for {$DBBACKUP.NODATA.PERIOD}",
+                                        "priority": "AVERAGE",
+                                        "manual_close": "YES",
+                                        "description": "The backup job stopped reporting to Zabbix at all - the container is down, scheduling is disabled or monitoring is misconfigured. Unlike the age based triggers this does not depend on the last reported backup timestamp."
                                     }
                                 ]
                             }
@@ -291,6 +300,13 @@
                     {
                         "tag": "Service",
                         "value": "Database"
+                    }
+                ],
+                "macros": [
+                    {
+                        "macro": "{$DBBACKUP.NODATA.PERIOD}",
+                        "value": "2d",
+                        "description": "How long a backup job may stay silent before the 'No statistics received' trigger fires."
                     }
                 ],
                 "valuemaps": [


### PR DESCRIPTION
## Tiered "No backups detected" triggers could never fire

Each of the 3, 4 and 5 day expressions additionally required `fuzzytime(...,172800s)<>0` — "the backup is younger than 2 days" — while at the same time demanding it be older than 3, 4 or 5 days. That is a contradiction, so **none of them could ever fire**.

Worse, the 2 day trigger required the backup to be younger than 3 days, so once a job had been failing for three days its alarm resolved itself and the template went quiet exactly when it mattered most.

Each tier now checks only its own lower bound and the next tier's, and the 5 day tier has no upper bound:

```
2 days:  fuzzytime(...,172800s)=0 and fuzzytime(...,259200s)<>0
3 days:  fuzzytime(...,259200s)=0 and fuzzytime(...,345600s)<>0
4 days:  fuzzytime(...,345600s)=0 and fuzzytime(...,432000s)<>0
5 days:  fuzzytime(...,432000s)=0
```

The 5 day boundary was also written as `432800s` (5.009 days) instead of `432000s`.

## "Backup 20% Smaller in Size" compared against 80%

`last(size)/last(size,#2)<0.2` fires when a backup shrank to under a fifth — 80% smaller, not the 20% the name promises. A backup could lose three quarters of its content without a word. It now compares against `0.8`, and both ratio triggers require a non zero previous value so they no longer end up unsupported after a zero sized backup.

## Added: "No statistics received"

A `nodata()` trigger driven by a new `{$DBBACKUP.NODATA.PERIOD}` macro (default `2d`). The age based triggers work off the last reported backup timestamp; this one fires when a job stops reporting to Zabbix altogether.

## Housekeeping

- export version raised to `7.4`
- `units: B` on the backup size item, so the frontend stops showing raw byte counts
- template description points at this repository instead of the `tiredofit` one
- item tags deliberately left on the existing `Application` convention, so saved filters keep working

**All UUIDs are unchanged**, so a re-import updates the existing objects in place rather than creating duplicates.

## Testing

Verified against a live Zabbix 7.4.14 instance: `configuration.import` returns `true`, and the API reads back all 9 trigger prototypes with their expressions parsed, the macro resolving in the `nodata` expression, and the new units.

The tier coverage was additionally simulated across backup ages from 0 to 10 days — exactly one trigger is active at every age from 2 days on, with no gaps and no overlaps.

## Out of scope, but worth knowing

While testing I confirmed a separate problem in the sender, which this PR does **not** address. `dbbackup_post_dbbackup` sends an LLD payload containing only its own job:

```bash
zabbix_sender ... -k dbbackup.backup -o '[{"{#NAME}":"'${backup_job_db_host}.${backup_job_db_name}'"}]'
```

Zabbix treats every LLD receipt as the complete list. With two jobs in one container I measured, on Zabbix 7.4.14, that each send **immediately disables** the other job's items — `enabled_lifetime_type=2` is the default — together with all nine of its triggers, and schedules them for deletion after `lifetime=7d`. The jobs take turns silencing each other's alerting entirely. Sending both names in one payload restores them.

Related: `{#NAME}` uses `${backup_job_db_name}`, which is never reassigned inside the per-database loops, so a job with `DB_NAME=ALL` collapses every database into one item set.

Happy to open a separate PR for either if you have a preference on the approach — both change `{#NAME}`, which orphans existing history, so it seemed worth asking first.

## Note

This branch is independent of my two other PRs. It adds a `4.9.3` CHANGELOG heading, as does #493 — whichever merges second will need a trivial conflict resolution at the top of the file.
